### PR TITLE
DEV: Remove search banner dependency

### DIFF
--- a/about.json
+++ b/about.json
@@ -13,7 +13,6 @@
   },
   "components": [
     "https://github.com/discourse/discourse-sidebar-new-topic-button.git",
-    "https://github.com/discourse/discourse-search-banner.git",
     "https://github.com/discourse/discourse-full-width-component.git"
   ],
   "color_schemes": {


### PR DESCRIPTION
Followup dfa22d21b6a49bb4ebaf590b16578cbc35c2894e,
the search banner has been replaced in core
with the welcome banner, this is no longer needed,
c.f. https://github.com/discourse/discourse/pull/31516
