### PR TITLE
Update styling of  overlapping alert new/updated topics

### DIFF
--- a/scss/main.scss
+++ b/scss/main.scss
@@ -90,6 +90,16 @@ body:not(.has-full-page-chat) {
 }
 
 .list-container {
+  .show-more.has-topics {
+    right: 50%;
+    transform: translateX(50%);
+
+    .alert {
+      padding: var(--spacing-block-sm) var(--spacing-inline-m);
+      border-radius: var(--d-border-radius-large);
+      font-size: var(--font-down-1-rem);
+    }
+  }
   .topic-list-body {
     padding-top: var(--spacing-block-m);
   }

--- a/scss/misc.scss
+++ b/scss/misc.scss
@@ -90,3 +90,7 @@ input[type="color"]:focus,
   border-radius: var(--d-border-radius);
   background-color: var(--primary-50);
 }
+
+.alert.alert-info {
+  background: var(--tertiary-very-low);
+}


### PR DESCRIPTION
Still not ideal but a slight improvement to the fully-overlapping alert banner 

| Before | After |
|--------|--------|
| ![CleanShot 2025-03-18 at 08 26 22](https://github.com/user-attachments/assets/433a9918-f1aa-4e55-a21f-ea3f46eaf1d5) | ![CleanShot 2025-03-18 at 08 24 33](https://github.com/user-attachments/assets/c8f97dc2-ad1c-46f5-a5cd-5cb3aa29aa35) |