### PR TITLE
Hide message section in sidebar

### DIFF
--- a/scss/hiddenstuff.scss
+++ b/scss/hiddenstuff.scss
@@ -4,6 +4,7 @@
 .pinned-button .reason .text,
 .more-topics__browse-more,
 //footer-message might cause issues, not sure what possible stuff can be in there, but the general idea is to hide it bcs having an ugly H3 (what?) CTA at the bottom is just… ugly imo
-.footer-message {
+.footer-message,
+.sidebar-section[data-section-name="messages"] {
   display: none;
 }


### PR DESCRIPTION
This was the original plan, along with tags, but only doing messages for now.