### PR TITLE
Button hover style reapply

### DIFF
--- a/scss/color-exploration.scss
+++ b/scss/color-exploration.scss
@@ -63,7 +63,7 @@
     oklch(from var(--accent-color) calc(l * 0.2) calc(c * 0.01) h / 0.25)
   );
   --button-box-shadow: light-dark(
-    oklch(from var(--accent-color) calc(l * 2) calc(c * 0.125) h),
+    oklch(from var(--accent-color) calc(l * 1.5) calc(c * 0.35) h),
     oklch(from var(--accent-color) calc(l * 0.75) calc(c * 0.5) h)
   );
   --d-selected: light-dark(

--- a/scss/misc.scss
+++ b/scss/misc.scss
@@ -90,3 +90,7 @@ input[type="color"]:focus,
   border-radius: var(--d-border-radius);
   background-color: var(--primary-50);
 }
+
+.discourse-reactions-list .reactions {
+  gap: 0.15em;
+}


### PR DESCRIPTION
Re-adding the hover effect for buttons by making the button-box-shadow colour visible

![CleanShot 2025-03-18 at 09 08 30@2x](https://github.com/user-attachments/assets/e96a3023-ecea-420c-a6d1-1bc370bd05f1)
VS
![CleanShot 2025-03-18 at 09 08 53@2x](https://github.com/user-attachments/assets/bcb990c2-4341-4f7a-a5fc-bdf0faca304e)
