### PR TITLE
UX: apply anti-aliased font to topics as well

### DIFF
--- a/scss/topic.scss
+++ b/scss/topic.scss
@@ -2,6 +2,7 @@
   .contents {
     font-size: var(--font-up-1);
     line-height: 1.25;
+    -webkit-font-smoothing: antialiased;
   }
 }
 


### PR DESCRIPTION
We've had `-webkit-font-smoothing: antialiased` applied in the Horizon theme for awhile, but it was not applying to the content in the topic post stream for some reason. It will with this PR.

**Before**
![CleanShot 2025-03-18 at 17 55 38@2x](https://github.com/user-attachments/assets/abb8029c-06e4-4191-8186-0a8ebdaab6b1)


**After**
![CleanShot 2025-03-18 at 17 54 41@2x](https://github.com/user-attachments/assets/9c1ed1ae-4d42-4a9c-a029-637347229880)
