### PR TITLE
UX: Adjust topic timeline z-index

### DIFF
--- a/scss/topic.scss
+++ b/scss/topic.scss
@@ -11,6 +11,7 @@
   top: calc(
     var(--header-offset, 60px) + 53px + calc(var(--spacing-block-l) * 2)
   );
+  z-index: 300;
 }
 
 .timeline-container .topic-timeline {
@@ -49,7 +50,7 @@
 
 #topic-title {
   @include breakpoint(medium, $rule: min-width) {
-    z-index: z("composer", "content") - 1;
+    z-index: 299;
     padding: var(--spacing-block-m) var(--spacing-inline-xl);
     margin-bottom: 0;
     position: sticky;


### PR DESCRIPTION
This PR fixes the admin wrench from not showing due to topic title z-index.