### PR TITLE
UX: Add theme settings and value transformers

### DIFF
--- a/javascripts/discourse/api-initializers/horizon.gjs
+++ b/javascripts/discourse/api-initializers/horizon.gjs
@@ -1,6 +1,6 @@
 import { apiInitializer } from "discourse/lib/api";
-import CustomUserPalette from "../components/custom-user-palette";
 import CustomColorHtmlClass from "../components/custom-color-html-class";
+import CustomUserPalette from "../components/custom-user-palette";
 import ExperimentalScreen from "../components/experimental-screen";
 
 export default apiInitializer("1.8.0", (api) => {
@@ -8,11 +8,11 @@ export default apiInitializer("1.8.0", (api) => {
   api.renderInOutlet("above-main-container", CustomColorHtmlClass);
   api.renderInOutlet("sidebar-footer-actions", CustomUserPalette);
 
-  api.registerValueTransformer("enable-welcome-banner", () => {
+  api.registerValueTransformer("site-setting-enable-welcome-banner", () => {
     return settings.enable_welcome_banner;
   });
 
-  api.registerValueTransformer("search-experience", () => {
+  api.registerValueTransformer("site-setting-search-experience", () => {
     return settings.search_experience;
   });
 });

--- a/javascripts/discourse/api-initializers/horizon.gjs
+++ b/javascripts/discourse/api-initializers/horizon.gjs
@@ -1,8 +1,18 @@
 import { apiInitializer } from "discourse/lib/api";
+import CustomUserPalette from "../components/custom-user-palette";
 import CustomColorHtmlClass from "../components/custom-color-html-class";
 import ExperimentalScreen from "../components/experimental-screen";
 
 export default apiInitializer("1.8.0", (api) => {
   api.renderInOutlet("above-main-container", ExperimentalScreen);
   api.renderInOutlet("above-main-container", CustomColorHtmlClass);
+  api.renderInOutlet("sidebar-footer-actions", CustomUserPalette);
+
+  api.registerValueTransformer("enable-welcome-banner", () => {
+    return settings.enable_welcome_banner;
+  });
+
+  api.registerValueTransformer("search-experience", () => {
+    return settings.search_experience;
+  });
 });

--- a/javascripts/discourse/api-initializers/user-pallette.js
+++ b/javascripts/discourse/api-initializers/user-pallette.js
@@ -1,6 +1,0 @@
-import { apiInitializer } from "discourse/lib/api";
-import CustomUserPalette from "../components/custom-user-palette";
-
-export default apiInitializer("1.8.0", (api) => {
-  api.renderInOutlet("sidebar-footer-actions", CustomUserPalette);
-});

--- a/settings.yml
+++ b/settings.yml
@@ -8,4 +8,4 @@ search_experience:
   choices:
     - search_field
     - search_icon
-  description: "Overrides the core `search field` site setting"
+  description: "Overrides the core `search experience` site setting"

--- a/settings.yml
+++ b/settings.yml
@@ -1,0 +1,11 @@
+enable_welcome_banner:
+  default: true
+  description: "Overrides the core `enable welcome banner` site setting"
+
+search_experience:
+  type: enum
+  default: search_field
+  choices:
+    - search_field
+    - search_icon
+  description: "Overrides the core `search field` site setting"


### PR DESCRIPTION
This commit adds the above for these core site
settings:

* search_experience
* enable_welcome_banner

Since for horizon we want better control of
the default experience of these settings OOTB.

See also https://github.com/discourse/discourse/pull/31917
