### PR TITLE
DEV: Use new is_hot_topic serializer

### DIFF
--- a/about.json
+++ b/about.json
@@ -9,7 +9,8 @@
   "maximum_discourse_version": null,
   "assets": {},
   "modifiers": {
-    "svg_icons": ["fire"]
+    "svg_icons": ["fire"],
+    "serialize_topic_is_hot": true
   },
   "components": [
     "https://github.com/discourse/discourse-sidebar-new-topic-button.git",

--- a/javascripts/discourse/components/card/topic-status-column.gjs
+++ b/javascripts/discourse/components/card/topic-status-column.gjs
@@ -11,7 +11,7 @@ export default class TopicStatusColumn extends Component {
   }
 
   get badge() {
-    if (this.heatMap) {
+    if (this.args.topic.is_hot) {
       return {
         icon: "fire",
         text: "topic_hot",

--- a/javascripts/discourse/components/card/topic-status-column.gjs
+++ b/javascripts/discourse/components/card/topic-status-column.gjs
@@ -6,10 +6,6 @@ import { i18n } from "discourse-i18n";
 export default class TopicStatusColumn extends Component {
   @service siteSettings;
 
-  get heatMap() {
-    return this.args.topic.views > this.siteSettings.topic_views_heat_medium;
-  }
-
   get badge() {
     if (this.args.topic.is_hot) {
       return {


### PR DESCRIPTION
This PR moves to use the new serializer in core to detect if topics should have the `hot` badge attached.

This PR should only be merged once this core change is merged -> https://github.com/discourse/discourse/pull/31935