### PR TITLE
UX: change category nav background on mobile

### DIFF
--- a/scss/mobile-stuff.scss
+++ b/scss/mobile-stuff.scss
@@ -36,6 +36,7 @@
           row-gap: var(--spacing-block-xs);
           flex-basis: 100%;
           .select-kit-header {
+            background: var(--d-content-background);
             padding-block: var(--spacing-block-s);
             padding-inline: 0;
             border: 0;


### PR DESCRIPTION
In dark mode `--d-content-background` and `--secondary` don't match, causing this dropdown bg issue: 


Before:
![image](https://github.com/user-attachments/assets/9cbfb550-6d1c-499d-950c-8e6e96e4b25d)


After:
![image](https://github.com/user-attachments/assets/69097c6b-6f3a-4e79-9201-7d69b595e04b)

