### PR TITLE
UX: add tags-index container

### DIFF
--- a/scss/main.scss
+++ b/scss/main.scss
@@ -73,7 +73,8 @@ body:not(.has-full-page-chat) {
       .body-page,
       .container.badges,
       .topic-above-footer-buttons-outlet .presence-users,
-      .global-notice {
+      .global-notice,
+      .container.tags-index {
         @include breakpoint(medium, $rule: min-width) {
           max-width: 1000px;
           margin-inline: auto;


### PR DESCRIPTION
This container was missing from the list

Before:
![image](https://github.com/user-attachments/assets/2b2ac2e7-96d6-4512-9e7e-0d53ee961a56)


After:
![image](https://github.com/user-attachments/assets/5601ebfd-2bbf-452b-bae9-c0e883f5b6d3)
