### PR TITLE
Composer styling on desktop

### DIFF
--- a/scss/composer.scss
+++ b/scss/composer.scss
@@ -9,6 +9,38 @@
     }
   }
 }
+
+#reply-control.hide-preview {
+  @include breakpoint("mobile-extra-large", $rule: min-width) {
+    background: var(--d-content-background);
+
+    .grippie {
+      background: var(--tertiary-low);
+    }
+
+    &:has(.in-focus) .grippie {
+      background: var(--tertiary);
+    }
+
+    .reply-area {
+      padding-inline: 0;
+    }
+    .reply-to,
+    .submit-panel {
+      padding-inline: var(--spacing-inline-sm);
+    }
+
+    .d-editor-textarea-wrapper {
+      border: 0;
+      border-bottom: 1px solid var(--primary-low);
+      border-radius: 0;
+
+      &.in-focus {
+        outline: 0;
+      }
+    }
+  }
+}
 .d-editor-button-bar {
   .btn:hover,
   .toolbar-popup-menu-options.is-expanded {

--- a/scss/composer.scss
+++ b/scss/composer.scss
@@ -14,8 +14,26 @@
   @include breakpoint("mobile-extra-large", $rule: min-width) {
     background: var(--d-content-background);
 
+    border-top-right-radius: var(--d-border-radius);
+    border-top-left-radius: var(--d-border-radius);
+    overflow: hidden;
+
     .grippie {
       background: var(--tertiary-low);
+    }
+
+    .title-and-category {
+      padding: 0 var(--spacing-inline-m);
+      width: calc(100% - var(--spacing-inline-m) * 2);
+    }
+
+    .d-editor-button-bar {
+      padding: 3px var(--spacing-inline-m);
+      border: none;
+    }
+
+    .d-editor-input {
+      padding: var(--spacing-inline-m);
     }
 
     &:has(.in-focus) .grippie {

--- a/scss/misc.scss
+++ b/scss/misc.scss
@@ -40,10 +40,6 @@
   border-radius: 0;
 }
 
-.d-editor-button-bar {
-  padding: 3px;
-}
-
 .open .grippie {
   background-color: var(--accent-color);
 }


### PR DESCRIPTION
A more lightweight and sleek styling for the theme. Only applies on desktop with preview hidden.
* removed area border
* moved focus indicator to grippie
* changed to one-colour background for entire element

| Before | After |
|--------|--------|
| ![CleanShot 2025-03-27 at 16 35 20@2x](https://github.com/user-attachments/assets/8ad6c0db-5c49-43bd-a7fd-8371afe69548) | ![CleanShot 2025-03-27 at 16 35 01@2x](https://github.com/user-attachments/assets/c10c6687-8c68-4c07-9526-d2e975604be3) |