### PR TITLE
UX: Topic list layout changes

### DIFF
--- a/javascripts/discourse/components/card/topic-activity-column.gjs
+++ b/javascripts/discourse/components/card/topic-activity-column.gjs
@@ -36,7 +36,11 @@ export default class TopicActivityColumn extends Component {
         {{i18n (themePrefix this.activityText)}}
       </div>
       <div class="topic-activity__time">
-        {{formatDate @topic.bumpedAt}}
+        {{formatDate
+          @topic.bumpedAt
+          leaveAgo="true"
+          format="medium-with-ago-and-on"
+        }}
       </div>
       {{#if this.displayUnreadPosts}}
         <span class="topic-post-badges">

--- a/javascripts/discourse/components/card/topic-activity-column.gjs
+++ b/javascripts/discourse/components/card/topic-activity-column.gjs
@@ -1,27 +1,10 @@
 import Component from "@glimmer/component";
 import avatar from "discourse/helpers/avatar";
-import concatClass from "discourse/helpers/concat-class";
 import formatDate from "discourse/helpers/format-date";
 import { i18n } from "discourse-i18n";
 import gt from "truth-helpers/helpers/gt";
 
 export default class TopicActivityColumn extends Component {
-  get displayUnreadPosts() {
-    return (
-      this.args.topic.unread_posts ||
-      this.args.topic.new_posts ||
-      this.args.topic.unseen
-    );
-  }
-
-  get badgeClass() {
-    return this.args.topic.unread_posts || this.args.topic.new_posts
-      ? "unread-posts"
-      : this.args.topic.unseen
-      ? "new-topic"
-      : "";
-  }
-
   get activityText() {
     // this should handle any case where a topic was no bumped due to a reply/post
     if (
@@ -62,15 +45,6 @@ export default class TopicActivityColumn extends Component {
           format="medium-with-ago-and-on"
         }}
       </div>
-      {{#if this.displayUnreadPosts}}
-        <span class="topic-post-badges">
-          <a
-            href={{@topic.url}}
-            title={{i18n "topic.unread_posts" count=this.displayUnreadPosts}}
-            class={{concatClass "badge badge-notification" this.badgeClass}}
-          >{{this.displayUnreadPosts}}</a>
-        </span>
-      {{/if}}
     </span>
   </template>
 }

--- a/javascripts/discourse/components/card/topic-activity-column.gjs
+++ b/javascripts/discourse/components/card/topic-activity-column.gjs
@@ -1,12 +1,25 @@
 import Component from "@glimmer/component";
 import avatar from "discourse/helpers/avatar";
+import concatClass from "discourse/helpers/concat-class";
 import formatDate from "discourse/helpers/format-date";
 import { i18n } from "discourse-i18n";
 import gt from "truth-helpers/helpers/gt";
 
 export default class TopicActivityColumn extends Component {
   get displayUnreadPosts() {
-    return this.args.topic.unread_posts || this.args.topic.new_posts;
+    return (
+      this.args.topic.unread_posts ||
+      this.args.topic.new_posts ||
+      this.args.topic.unseen
+    );
+  }
+
+  get badgeClass() {
+    return this.args.topic.unread_posts || this.args.topic.new_posts
+      ? "unread-posts"
+      : this.args.topic.unseen
+      ? "new-topic"
+      : "";
   }
 
   get activityText() {
@@ -54,7 +67,7 @@ export default class TopicActivityColumn extends Component {
           <a
             href={{@topic.url}}
             title={{i18n "topic.unread_posts" count=this.displayUnreadPosts}}
-            class="badge badge-notification unread-posts"
+            class={{concatClass "badge badge-notification" this.badgeClass}}
           >{{this.displayUnreadPosts}}</a>
         </span>
       {{/if}}

--- a/javascripts/discourse/components/card/topic-activity-column.gjs
+++ b/javascripts/discourse/components/card/topic-activity-column.gjs
@@ -10,6 +10,13 @@ export default class TopicActivityColumn extends Component {
   }
 
   get activityText() {
+    // this should handle any case where a topic was no bumped due to a reply/post
+    if (
+      moment(this.args.topic.bumped_at).isAfter(this.args.topic.last_posted_at)
+    ) {
+      return "user_updated";
+    }
+
     if (this.args.topic.posts_count > 1) {
       return "user_replied";
     } else if (this.args.topic.posts_count === 1) {

--- a/javascripts/discourse/components/card/topic-replies-column.gjs
+++ b/javascripts/discourse/components/card/topic-replies-column.gjs
@@ -2,8 +2,9 @@ import icon from "discourse/helpers/d-icon";
 import gt from "truth-helpers/helpers/gt";
 
 const TopicRepliesColumn = <template>
-  {{#if (gt @topic.posts_count 1)}}
-    <span class="topic-replies">{{icon "reply"}}{{@topic.posts_count}}</span>
+  {{log @topic}}
+  {{#if (gt @topic.replyCount 1)}}
+    <span class="topic-replies">{{icon "reply"}}{{@topic.replyCount}}</span>
   {{/if}}
 </template>;
 

--- a/javascripts/discourse/components/card/topic-replies-column.gjs
+++ b/javascripts/discourse/components/card/topic-replies-column.gjs
@@ -2,7 +2,6 @@ import icon from "discourse/helpers/d-icon";
 import gt from "truth-helpers/helpers/gt";
 
 const TopicRepliesColumn = <template>
-  {{log @topic}}
   {{#if (gt @topic.replyCount 1)}}
     <span class="topic-replies">{{icon "reply"}}{{@topic.replyCount}}</span>
   {{/if}}

--- a/javascripts/discourse/initializers/topic-list-columns.gjs
+++ b/javascripts/discourse/initializers/topic-list-columns.gjs
@@ -68,6 +68,9 @@ export default {
           if (context.topic.pinned || context.topic.pinned_globally) {
             classes.push("--pinned");
           }
+          if (context.topic.is_hot) {
+            classes.push("--hot");
+          }
           return classes;
         }
       );

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -5,4 +5,5 @@ en:
   topic_hot: "Hot"
   user_replied: "replied"
   user_posted: "posted"
+  user_updated: "updated"
 

--- a/scss/topic-cards.scss
+++ b/scss/topic-cards.scss
@@ -179,17 +179,17 @@
   td.main-link .link-top-line a.raw-topic-link {
     padding: 0;
   }
-  .link-top-line .topic-post-badges .badge-notification.unread-posts,
-  .link-top-line .topic-post-badges .badge-notification.new-topic {
-    display: none;
-  }
-  .topic-post-badges .badge-notification.unread-posts {
+
+  .topic-post-badges .badge-notification.unread-posts,
+  .topic-post-badges .badge-notification.new-topic {
     background-color: var(--tertiary);
     color: var(--tertiary);
     overflow: hidden;
     height: 8px;
     width: 8px;
     padding: 0;
+    top: -2px;
+    min-width: unset;
   }
 
   // excerpt

--- a/scss/topic-cards.scss
+++ b/scss/topic-cards.scss
@@ -30,7 +30,7 @@
   border: 1px solid var(--primary-300);
   display: grid;
   grid-template-columns: 20px min-content min-content auto min-content min-content min-content;
-  grid-template-rows: 20px minmax(20px, auto);
+  grid-template-rows: auto minmax(20px, auto);
   grid-template-areas:
     ". . . . . . status"
     "activity activity activity activity activity likes-replies category";
@@ -39,7 +39,6 @@
   border-radius: var(--d-border-radius);
   @include breakpoint(extra-large) {
     grid-template-columns: 20px repeat(6, 1fr);
-    grid-template-rows: 20px minmax(20px, auto);
     grid-template-areas:
       ". . . . . . status"
       "activity activity activity activity activity likes-replies category";
@@ -58,7 +57,7 @@
   }
   &.excerpt-expanded {
     grid-template-columns: 20px auto repeat(5, 1fr) auto;
-    grid-template-rows: 20px auto auto 30px;
+    grid-template-rows: auto auto auto 30px;
     grid-template-areas:
       ". . . . . . . status"
       "activity activity activity activity activity activity activity activity"

--- a/scss/topic-cards.scss
+++ b/scss/topic-cards.scss
@@ -32,23 +32,42 @@
   grid-template-columns: 20px min-content min-content auto min-content min-content min-content;
   grid-template-rows: 20px minmax(20px, auto);
   grid-template-areas:
-    "activity activity activity activity . . status"
-    "topic-title topic-title topic-title topic-title likes-replies likes-replies category";
+    ". . . . . . status"
+    "activity activity activity activity activity likes-replies category";
   grid-column-gap: 12px;
   grid-row-gap: 8px;
   border-radius: var(--d-border-radius);
+  @include breakpoint(extra-large) {
+    grid-template-columns: 20px repeat(6, 1fr);
+    grid-template-rows: 20px minmax(20px, auto);
+    grid-template-areas:
+      ". . . . . . status"
+      "activity activity activity activity activity likes-replies category";
+  }
+  @include breakpoint(mobile-extra-large) {
+    grid-template-columns: 25px repeat(7, 1fr);
+    grid-template-rows: auto auto auto;
+    grid-template-areas:
+      ". . . . . . . status"
+      "activity activity activity activity activity activity activity activity"
+      "category category category category . . . likes-replies";
+    border: none;
+    border-bottom: 1px solid var(--primary-200);
+    box-shadow: none;
+    border-radius: 0;
+  }
   &.excerpt-expanded {
     grid-template-columns: 20px auto repeat(5, 1fr) auto;
     grid-template-rows: 20px auto auto 30px;
     grid-template-areas:
-      "activity activity activity activity . . . status"
-      "topic-title topic-title topic-title topic-title topic-title topic-title . ."
+      ". . . . . . . status"
+      "activity activity activity activity activity activity activity activity"
       "excerpt excerpt excerpt excerpt excerpt excerpt . ."
       "excerpt excerpt excerpt excerpt excerpt excerpt likes-replies category";
     @include breakpoint(extra-large) {
       grid-template-areas:
-        "activity activity activity activity . . . status"
-        "topic-title topic-title topic-title topic-title topic-title topic-title . ."
+        ". . . . . . . status"
+        "activity activity activity activity activity activity activity activity"
         "excerpt excerpt excerpt excerpt excerpt excerpt excerpt likes-replies"
         "excerpt excerpt excerpt excerpt excerpt excerpt excerpt category";
     }
@@ -56,35 +75,13 @@
       grid-template-columns: 25px auto repeat(6, 1fr);
       grid-template-rows: auto auto auto;
       grid-template-areas:
-        "activity activity activity activity activity activity activity status"
-        "topic-title topic-title topic-title topic-title topic-title topic-title topic-title topic-title"
+        ". . . . . . . status"
+        "activity activity activity activity activity activity activity activity"
         "category . . . . . . likes-replies";
       .topic-excerpt {
         display: none;
       }
     }
-  }
-  @include breakpoint(large) {
-    grid-template-columns: 20px repeat(6, 1fr);
-    grid-template-rows: 20px minmax(20px, auto);
-    grid-template-areas:
-      "activity activity activity activity activity activity status"
-      "topic-title topic-title topic-title topic-title topic-title topic-title topic-title"
-      "category . . . . . likes-replies";
-  }
-  @include breakpoint(mobile-extra-large) {
-    grid-template-columns: 25px repeat(7, 1fr);
-    grid-template-rows: auto auto auto;
-    grid-template-areas:
-      "activity activity activity activity activity activity activity status"
-      "topic-title topic-title topic-title topic-title topic-title topic-title topic-title topic-title"
-      "category . . . . . . likes-replies";
-  }
-  @include breakpoint(mobile-extra-large) {
-    border: none;
-    border-bottom: 1px solid var(--primary-200);
-    box-shadow: none;
-    border-radius: 0;
   }
 
   // display contents
@@ -121,21 +118,22 @@
     border-radius: 4px;
   }
 
+  .topic-activity__username {
+    @include breakpoint(tablet) {
+      display: none;
+    }
+  }
+
+  @include breakpoint("large", min-width) {
+    position: relative;
+  }
+
   // status
   .topic-status-data {
     grid-area: status;
-    position: relative;
   }
   .topic-status-card {
-    @include breakpoint("large", min-width) {
-      position: absolute;
-      right: 0px;
-      top: -20px;
-      background-color: var(--d-content-background);
-      height: 85%;
-      font-size: var(--font-down-3);
-    }
-    height: 100%;
+    height: 20px;
     margin-left: auto;
     display: flex;
     flex-direction: row;
@@ -148,9 +146,6 @@
     border: 1px solid var(--status-color);
     color: var(--status-color);
     width: min-content;
-    @include breakpoint(mobile-extra-large) {
-      height: calc(100% - 2px);
-    }
     svg {
       font-size: var(--font-down-1);
       color: var(--status-color);
@@ -167,7 +162,8 @@
   // title
   td.main-link .link-top-line {
     font-size: var(--font-0);
-    grid-area: topic-title;
+    grid-row: 1/2;
+    grid-column: 1/-2;
     font-weight: 500;
     display: flex;
   }
@@ -229,13 +225,16 @@
   }
   td.topic-category-data {
     grid-area: category;
-    align-self: flex-end;
+    display: flex;
+    justify-content: flex-end;
+    @include breakpoint(tablet) {
+      justify-content: flex-start;
+    }
   }
   td.topic-category-data .badge-category__wrapper,
   td.main-link .link-bottom-line .badge-category__wrapper {
     border-radius: var(--d-border-radius);
     padding: 3px 6px;
-    align-self: flex-end;
     background-color: light-dark(
       oklch(from var(--category-badge-color) 97% calc(c * 0.3) h),
       oklch(from var(--category-badge-color) 45% calc(c * 0.5) h)
@@ -270,8 +269,7 @@
     gap: 0.5em;
     justify-content: flex-end;
     height: min-content;
-    align-self: flex-end;
-    padding-bottom: 4px;
+    align-self: center;
   }
   .topic-likes-replies-data .topic-likes,
   .topic-likes-replies-data .topic-replies {
@@ -304,32 +302,35 @@
 // Bookmarks
 
 .topic-list-item.bookmark-list-item {
+  .link-bottom-line {
+    font-size: unset;
+  }
   grid-template-columns: 20px min-content min-content auto min-content min-content 36px;
   grid-template-areas:
-    "avatar update metadata metadata metadata metadata dropdown"
-    "topic-title topic-title topic-title topic-title topic-title category dropdown";
+    ". . . . . . dropdown"
+    "avatar update metadata metadata metadata category dropdown";
   @include breakpoint(mobile-extra-large) {
     grid-template-columns: 20px min-content min-content auto min-content min-content min-content 36px;
     grid-template-areas:
-      "avatar update metadata metadata metadata metadata metadata dropdown"
-      "topic-title topic-title topic-title topic-title topic-title likes-replies category dropdown";
+      ". . . . . . . dropdown"
+      "avatar update metadata metadata metadata metadata category dropdown";
   }
   &.has-metadata {
     grid-template-areas:
-      "avatar update metadata metadata metadata metadata dropdown"
-      "topic-title topic-title topic-title topic-title likes-replies category dropdown";
+      ". . . . . . dropdown"
+      "avatar update metadata metadata metadata category dropdown";
     @include breakpoint(mobile-extra-large) {
       grid-template-areas:
-        "avatar update metadata metadata metadata metadata metadata dropdown"
-        "topic-title topic-title topic-title topic-title likes-replies . category dropdown";
+        ". . . . . . . dropdown"
+        "avatar update metadata metadata metadata metadata category dropdown";
     }
   }
   &.excerpt-expanded {
     grid-template-areas:
+      ". . . . . . . dropdown"
       "avatar update metadata metadata metadata metadata metadata dropdown"
-      "topic-title topic-title topic-title topic-title topic-title topic-title . dropdown"
-      "excerpt excerpt excerpt excerpt excerpt excerpt . dropdown"
-      "excerpt excerpt excerpt excerpt excerpt excerpt category dropdown";
+      "excerpt excerpt excerpt excerpt excerpt . . dropdown"
+      "excerpt excerpt excerpt excerpt excerpt category category dropdown";
     @include breakpoint(mobile-extra-large) {
       grid-template-columns: 20px min-content min-content auto min-content min-content min-content 36px;
       .post-excerpt {
@@ -338,16 +339,23 @@
     }
     &.has-metadata {
       grid-template-areas:
+        ". . . . . . . dropdown"
         "avatar update metadata metadata metadata metadata metadata dropdown"
-        "topic-title topic-title topic-title topic-title topic-title topic-title topic-title dropdown"
-        "excerpt excerpt excerpt excerpt excerpt excerpt . dropdown"
-        "excerpt excerpt excerpt excerpt excerpt excerpt category dropdown";
+        "excerpt excerpt excerpt excerpt excerpt . . dropdown"
+        "excerpt excerpt excerpt excerpt excerpt category category dropdown";
     }
+  }
+  td.author-avatar {
+    grid-area: avatar;
   }
   td.main-link .link-bottom-line {
     display: contents;
     .badge-category__wrapper {
       grid-area: category;
+      display: flex;
+      align-items: center;
+      width: min-content;
+      justify-self: flex-end;
     }
   }
   td.main-link .link-top-line {
@@ -356,7 +364,8 @@
       grid-area: metadata;
     }
     .bookmark-status-with-link {
-      grid-area: topic-title;
+      grid-column: 1/-2;
+      grid-row: 1/2;
     }
   }
   .post-excerpt {
@@ -382,22 +391,19 @@
 // Assigned List
 
 .topic-list-item.assigned-list-item {
+  td.main-link .link-top-line {
+    grid-column: 1/-3;
+  }
   grid-template-columns: 20px min-content min-content auto min-content min-content 36px;
   grid-template-areas:
-    "activity activity activity activity activity status dropdown"
-    "topic-title topic-title topic-title topic-title likes-replies category dropdown";
-  @include breakpoint(large) {
-    grid-template-areas:
-      "activity activity activity activity activity status dropdown"
-      "topic-title topic-title topic-title topic-title topic-title topic-title dropdown"
-      "category . . . . likes-replies dropdown";
-  }
+    ". . . . . status dropdown"
+    "activity activity activity activity likes-replies category dropdown";
   @include breakpoint(mobile-extra-large) {
     grid-template-columns: 20px min-content min-content auto min-content min-content min-content 36px;
     grid-template-areas:
-      "activity activity activity activity activity activity status dropdown"
-      "topic-title topic-title topic-title topic-title topic-title topic-title . dropdown"
-      "category . . . . . likes-replies dropdown";
+      ". . . . . . status dropdown"
+      "activity activity activity activity activity activity activity dropdown"
+      "category category category category category category likes-replies dropdown";
   }
   .assign-topic-buttons {
     display: contents;
@@ -426,19 +432,19 @@ body.user-messages-page .topic-list-item {
   }
   grid-template-areas:
     "activity activity activity activity activity activity activity"
-    "topic-title topic-title topic-title topic-title likes-replies likes-replies likes-replies";
+    ". . . . likes-replies likes-replies likes-replies";
   &.excerpt-expanded {
     grid-template-columns: 20px repeat(6, 1fr) auto;
     grid-template-rows: 20px auto auto 30px;
     grid-template-areas:
       "activity activity activity activity activity activity activity activity"
-      "topic-title topic-title topic-title topic-title topic-title topic-title topic-title topic-title"
+      ". . . . . . . ."
       "excerpt excerpt excerpt excerpt excerpt excerpt . ."
       "excerpt excerpt excerpt excerpt excerpt excerpt likes-replies likes-replies";
     @include breakpoint(extra-large) {
       grid-template-areas:
         "avatar author status status . . . activity"
-        "avatar topic-title topic-title topic-title topic-title . . ."
+        "avatar . . . . . . ."
         ". excerpt excerpt excerpt excerpt excerpt . likes-replies"
         ". excerpt excerpt excerpt excerpt excerpt . likes-replies";
     }
@@ -448,7 +454,7 @@ body.user-messages-page .topic-list-item {
     grid-template-rows: auto auto;
     grid-template-areas:
       "activity activity activity activity activity activity activity activity"
-      "topic-title topic-title topic-title topic-title topic-title topic-title topic-title topic-title";
+      ". . . . . . . .";
     .topic-excerpt {
       display: none;
     }
@@ -460,7 +466,7 @@ body.user-messages-page .topic-list-item {
 .bulk-select-enabled .topic-list-item {
   grid-template-areas:
     "bulk-select activity activity activity . . status"
-    "bulk-select topic-title topic-title topic-title likes-replies likes-replies category";
+    "bulk-select . . . likes-replies likes-replies category";
   .bulk-select {
     grid-area: bulk-select;
     padding: 0;
@@ -476,7 +482,7 @@ body.user-messages-page .topic-list-item {
     grid-template-rows: 20px minmax(20px, auto);
     grid-template-areas:
       "bulk-select activity activity activity activity activity status"
-      "bulk-select topic-title topic-title topic-title topic-title topic-title topic-title"
+      "bulk-select . . . . . ."
       "bulk-select category . . . . likes-replies";
   }
   @include breakpoint(mobile-extra-large) {
@@ -484,7 +490,7 @@ body.user-messages-page .topic-list-item {
     grid-template-rows: auto auto auto;
     grid-template-areas:
       "bulk-select activity activity activity activity activity activity status"
-      "bulk-select topic-title topic-title topic-title topic-title topic-title topic-title topic-title"
+      "bulk-select . . . . . . ."
       "bulk-select category . . . . .  likes-replies";
   }
 }

--- a/scss/topic-cards.scss
+++ b/scss/topic-cards.scss
@@ -127,8 +127,20 @@
   .topic-status-data {
     grid-area: status;
   }
+  .topic-status-data {
+    grid-area: status;
+    position: relative;
+  }
   .topic-status-card {
-    height: 20px;
+    @include breakpoint("large", min-width) {
+      position: absolute;
+      right: 0px;
+      top: -20px;
+      background-color: var(--d-content-background);
+      height: 20px;
+      font-size: var(--font-down-3);
+    }
+    height: min-content;
     margin-left: auto;
     display: flex;
     flex-direction: row;

--- a/scss/topic-cards.scss
+++ b/scss/topic-cards.scss
@@ -50,7 +50,7 @@
     grid-template-areas:
       ". . . . . . . status"
       "activity activity activity activity activity activity activity activity"
-      "category category category category . . . likes-replies";
+      "category category category category category category category likes-replies";
     border: none;
     border-bottom: 1px solid var(--primary-200);
     box-shadow: none;
@@ -119,13 +119,9 @@
   }
 
   .topic-activity__username {
-    @include breakpoint(tablet) {
+    @include breakpoint(mobile-extra-large) {
       display: none;
     }
-  }
-
-  @include breakpoint("large", min-width) {
-    position: relative;
   }
 
   // status
@@ -227,7 +223,7 @@
     grid-area: category;
     display: flex;
     justify-content: flex-end;
-    @include breakpoint(tablet) {
+    @include breakpoint(mobile-extra-large) {
       justify-content: flex-start;
     }
   }

--- a/scss/topic-cards.scss
+++ b/scss/topic-cards.scss
@@ -179,7 +179,8 @@
   td.main-link .link-top-line a.raw-topic-link {
     padding: 0;
   }
-  .link-top-line .topic-post-badges .badge-notification.unread-posts {
+  .link-top-line .topic-post-badges .badge-notification.unread-posts,
+  .link-top-line .topic-post-badges .badge-notification.new-topic {
     display: none;
   }
   .topic-post-badges .badge-notification.unread-posts {
@@ -189,8 +190,6 @@
     height: 8px;
     width: 8px;
     padding: 0;
-    top: -2px;
-    min-width: unset;
   }
 
   // excerpt

--- a/spec/system/horizon_high_level_spec.rb
+++ b/spec/system/horizon_high_level_spec.rb
@@ -25,7 +25,7 @@ describe "Horizon theme | High level", type: :system do
     topic_item = find(topic_list.topic_list_item_class(topic_1))
     expect(topic_item.all("td").map { |el| el["class"] }).to eq(
       [
-        "main-link clearfix topic-list-data",
+        "main-link topic-list-data",
         "topic-activity-data",
         "topic-status-data",
         "topic-category-data",


### PR DESCRIPTION
This PR adjusts the topic card layout again a bit. It:

- Places title first & sub-info second. The activity data will now appear below the title.
- Adds more relevant text to the activity data `ago` and `on` when necessary
- Adjustments to breakpoints for when card changes from large view to smaller view

| Before | After |
| -- | -- | 
| ![CleanShot 2025-03-27 at 14 49 42@2x](https://github.com/user-attachments/assets/fd84a1d9-a57d-4c38-b405-3a440315c4ff) | ![CleanShot 2025-03-27 at 14 44 12@2x](https://github.com/user-attachments/assets/4a71a62a-9c19-4236-a717-d7c588d6992b) |
| ![CleanShot 2025-03-27 at 14 49 26@2x](https://github.com/user-attachments/assets/bffdc605-f2dd-475f-88b7-c6ee975a52bb) | ![CleanShot 2025-03-27 at 14 44 59@2x](https://github.com/user-attachments/assets/d8edbc9a-d56a-48d9-ab63-20ef3d440e7e) |
| ![CleanShot 2025-03-27 at 14 48 59@2x](https://github.com/user-attachments/assets/caf1665b-af16-48a5-ae21-e4fbd5f47b72) | ![CleanShot 2025-03-27 at 14 47 35@2x](https://github.com/user-attachments/assets/2d66af00-f9e3-4c17-8bea-11db3a369727)|


