### PR TITLE
FIX: Messed up CSS grid on messages list

### DIFF
--- a/scss/topic-cards.scss
+++ b/scss/topic-cards.scss
@@ -436,9 +436,6 @@ body.user-messages-page .topic-list-item {
   td.topic-status-data {
     display: none;
   }
-  grid-template-areas:
-    "activity activity activity activity activity activity activity"
-    ". . . . likes-replies likes-replies likes-replies";
   &.excerpt-expanded {
     grid-template-columns: 20px repeat(6, 1fr) auto;
     grid-template-rows: 20px auto auto 30px;


### PR DESCRIPTION
This needs a better follow-up, but the messages topic list
is currently busted. Removing the overridden topic-list-item
grid for messages helps.

**Before**

![image](https://github.com/user-attachments/assets/35558814-c959-4d23-a0c9-586d703a3c9a)

**After**

![image](https://github.com/user-attachments/assets/3022451a-858c-4c3d-a1c3-85f77625a36a)
