### PR TITLE
Lower z-index of powered-by-discourse badge

### DIFF
--- a/scss/misc.scss
+++ b/scss/misc.scss
@@ -8,7 +8,7 @@
 }
 
 .powered-by-discourse {
-  z-index: 9999;
+  z-index: 400;
 }
 
 .boxed.white {


### PR DESCRIPTION
Needs to be lowered to avoid overlap with composer