### PR TITLE
UX: adapt topic card layout for bookmarks & assigned list

### DIFF
--- a/scss/topic-cards.scss
+++ b/scss/topic-cards.scss
@@ -315,46 +315,78 @@
   .link-bottom-line {
     font-size: unset;
   }
-  grid-template-columns: 20px min-content min-content auto min-content min-content 36px;
+  //regular card without excerpt class
+  grid-template-columns: 20px min-content min-content auto min-content min-content min-content;
   grid-template-areas:
     ". . . . . . dropdown"
-    "avatar update metadata metadata metadata category dropdown";
+    "avatar update metadata metadata metadata . category";
   @include breakpoint(mobile-extra-large) {
-    grid-template-columns: 20px min-content min-content auto min-content min-content min-content 36px;
+    grid-template-columns: min-content min-content auto min-content min-content min-content min-content;
     grid-template-areas:
-      ". . . . . . . dropdown"
-      "avatar update metadata metadata metadata metadata category dropdown";
+      " . . . . . . dropdown"
+      "update metadata metadata metadata metadata category category";
+    .avatar {
+      display: none;
+    }
   }
   &.has-metadata {
-    grid-template-areas:
-      ". . . . . . dropdown"
-      "avatar update metadata metadata metadata category dropdown";
+    grid-template-columns: 20px min-content min-content auto min-content min-content min-content;
     @include breakpoint(mobile-extra-large) {
       grid-template-areas:
         ". . . . . . . dropdown"
         "avatar update metadata metadata metadata metadata category dropdown";
     }
   }
+
+  //card with excerpt (all in horizon since the toggle is gone)
   &.excerpt-expanded {
+    grid-template-columns: 20px min-content auto minmax(0, 100px);
+    @include breakpoint(extra-large, $rule: min-width) {
+      grid-template-columns: 20px min-content auto min-content;
+    }
     grid-template-areas:
-      ". . . . . . . dropdown"
-      "avatar update metadata metadata metadata metadata metadata dropdown"
-      "excerpt excerpt excerpt excerpt excerpt . . dropdown"
-      "excerpt excerpt excerpt excerpt excerpt category category dropdown";
+      ". . .  dropdown"
+      "avatar update metadata metadata"
+      "excerpt excerpt excerpt ."
+      "excerpt excerpt excerpt category";
+
+    .badge-category__wrapper {
+      align-self: flex-end;
+      height: min-content;
+      max-width: 100%;
+    }
+
     @include breakpoint(mobile-extra-large) {
-      grid-template-columns: 20px min-content min-content auto min-content min-content min-content 36px;
-      .post-excerpt {
+      grid-template-columns: auto min-content;
+      grid-template-areas:
+        ".  dropdown"
+        "category category";
+      .post-excerpt,
+      .avatar {
         display: none;
       }
     }
+
     &.has-metadata {
+      grid-template-columns: 20px min-content auto min-content;
       grid-template-areas:
-        ". . . . . . . dropdown"
-        "avatar update metadata metadata metadata metadata metadata dropdown"
-        "excerpt excerpt excerpt excerpt excerpt . . dropdown"
-        "excerpt excerpt excerpt excerpt excerpt category category dropdown";
+        ". . . dropdown"
+        "avatar update metadata ."
+        "excerpt excerpt excerpt . "
+        "excerpt excerpt excerpt category";
+      @include breakpoint(mobile-extra-large) {
+        grid-template-columns: auto min-content;
+        grid-template-areas:
+          " . dropdown"
+          "metadata category";
+
+        .bookmark-metadata {
+          flex-wrap: wrap;
+        }
+      }
     }
   }
+
   td.author-avatar {
     grid-area: avatar;
   }
@@ -372,12 +404,21 @@
     display: contents;
     .bookmark-metadata {
       grid-area: metadata;
+      margin: 0;
+      display: flex;
+      align-items: center;
+      gap: var(--spacing-inline-xs);
+    }
+    .bookmark-metadata-item {
+      margin: 0;
+      vertical-align: middle;
     }
     .bookmark-status-with-link {
       grid-column: 1/-2;
       grid-row: 1/2;
     }
   }
+
   .post-excerpt {
     grid-area: excerpt;
     margin: 0;
@@ -386,12 +427,24 @@
     display: contents;
     .bookmark-actions-dropdown {
       grid-area: dropdown;
-      align-self: center;
+      align-self: flex-start;
+      height: 1em;
+
+      .select-kit-header {
+        padding-top: 0;
+        margin-left: auto;
+        align-items: center;
+        background: transparent;
+      }
+      .select-kit-header-wrapper {
+        height: 1em;
+        width: 1em;
+      }
     }
   }
+
   .post-metadata.topic-list-data.updated-at {
     grid-area: update;
-    margin-left: auto;
   }
   td.activity .post-activity {
     display: none;
@@ -400,28 +453,40 @@
 
 // Assigned List
 .topic-list-item.assigned-list-item {
+  .topic-status-card {
+    display: none;
+  }
   td.main-link .link-top-line {
     grid-column: 1/-3;
   }
-  grid-template-columns: 20px min-content min-content auto min-content min-content 36px;
+  grid-template-columns: 20px min-content min-content auto min-content min-content min-content;
   grid-template-areas:
     ". . . . . status dropdown"
-    "activity . . . likes-replies category dropdown";
+    "activity . . . . likes-replies category";
   @include breakpoint(mobile-extra-large) {
-    td.main-link .link-top-line {
-      grid-column: 1/-2 !important;
-    }
     grid-template-columns: 20px min-content min-content auto min-content min-content min-content 36px;
     grid-template-areas:
       "category category . . . . status dropdown"
-      ". . . . . . . dropdown"
-      "activity . . . . . likes-replies dropdown";
+      ". . . . . . . . "
+      "activity . . . . . . likes-replies";
   }
   .assign-topic-buttons {
     display: contents;
     .assign-actions-dropdown {
       grid-area: dropdown;
-      align-self: center;
+      justify-content: flex-end;
+      height: 1em;
+
+      .select-kit-header {
+        padding-top: 0;
+        margin-left: auto;
+        align-items: center;
+        background: transparent;
+      }
+      .select-kit-header-wrapper {
+        height: 1em;
+        width: 1em;
+      }
     }
   }
   td.topic-category-status-data {

--- a/scss/topic-cards.scss
+++ b/scss/topic-cards.scss
@@ -371,7 +371,7 @@
       grid-template-columns: 20px min-content auto min-content;
       grid-template-areas:
         ". . . dropdown"
-        "avatar update metadata ."
+        "avatar update metadata metadata"
         "excerpt excerpt excerpt . "
         "excerpt excerpt excerpt category";
       @include breakpoint(mobile-extra-large) {


### PR DESCRIPTION
Simplified some of the grid layouts, rearranged for MQ/scenarios, and restyled the action dropdown to be less obtrusive. Also removed the status-tags from the topic-cards when displayed on these pages.

| MQ | Before | After |
|--------|--------|--------|
| Bookmarks, desktop - large |  ![CleanShot 2025-03-31 at 20 17 07@2x](https://github.com/user-attachments/assets/97b9699a-b570-4897-a9bf-56a5ff8c28eb) | ![CleanShot 2025-03-31 at 20 09 10@2x](https://github.com/user-attachments/assets/efc4ba29-5869-41c1-b99d-57f492ccb225) |
| Bookmarks, desktop - small | ![CleanShot 2025-03-31 at 20 18 23@2x](https://github.com/user-attachments/assets/55b6696e-b46e-493f-9d04-cd3c59b40fc9) | ![CleanShot 2025-03-31 at 20 11 02@2x](https://github.com/user-attachments/assets/045bad95-255e-4b8f-a651-3bfb889d78d3)|
| Bookmarks,mobile | ![CleanShot 2025-03-31 at 20 18 40@2x](https://github.com/user-attachments/assets/1de5f4a0-d440-4082-8520-a04779ef5883) | ![CleanShot 2025-03-31 at 20 11 52@2x](https://github.com/user-attachments/assets/6cd673c5-73d5-4b01-bcc2-98a27a7fc807) |
| Assigned, desktop - large | ![CleanShot 2025-03-31 at 20 16 38@2x](https://github.com/user-attachments/assets/df5013d7-61ed-44f3-9adc-84fdbe1033cc) | ![CleanShot 2025-03-31 at 20 16 19@2x](https://github.com/user-attachments/assets/782357b6-c6eb-453c-88b7-7c07004241d0) |
| Assigned, desktop - small | ![CleanShot 2025-03-31 at 20 15 10@2x](https://github.com/user-attachments/assets/8b42507b-3be8-4a2b-8969-fbf701ff26c4) | ![CleanShot 2025-03-31 at 20 15 58@2x](https://github.com/user-attachments/assets/92a2fff0-2886-4b6b-864a-3c5f322b363d) | 
| Assigned, mobile | ![CleanShot 2025-03-31 at 20 14 45@2x](https://github.com/user-attachments/assets/62edb10f-20f0-4414-a803-195ea88beda1) | ![CleanShot 2025-03-31 at 20 12 48@2x](https://github.com/user-attachments/assets/c25fd68f-4aed-4e83-bc71-6393ce5fa054) | 