### PR TITLE
UX: fix category nav padding on small screens

### DIFF
--- a/scss/mobile-stuff.scss
+++ b/scss/mobile-stuff.scss
@@ -43,7 +43,6 @@
           }
           .select-kit-header {
             background: var(--d-content-background);
-
             border: 0;
           }
         }

--- a/scss/mobile-stuff.scss
+++ b/scss/mobile-stuff.scss
@@ -35,10 +35,12 @@
           column-gap: var(--spacing-inline-s);
           row-gap: var(--spacing-block-xs);
           flex-basis: 100%;
+          li {
+            margin-right: 0;
+            margin-left: -0.35em;
+          }
           .select-kit-header {
             background: var(--d-content-background);
-            padding-block: var(--spacing-block-s);
-            padding-inline: 0;
             border: 0;
           }
         }

--- a/scss/mobile-stuff.scss
+++ b/scss/mobile-stuff.scss
@@ -37,10 +37,13 @@
           flex-basis: 100%;
           li {
             margin-right: 0;
-            margin-left: -0.35em;
+            margin-left: calc(
+              (var(--spacing-block-s) - 2px) * -1
+            ); // 2px is width of the outline
           }
           .select-kit-header {
             background: var(--d-content-background);
+
             border: 0;
           }
         }


### PR DESCRIPTION
This adjusts the active state of the dropdown by employing negative margin to compensate for the padding 

before:
![image](https://github.com/user-attachments/assets/e8c8a544-3527-4d6c-a513-0291a6a15ab5)


after:
![image](https://github.com/user-attachments/assets/4a53a0ee-a07d-43b0-9ab6-3542d86bbe8c)
