### PR TITLE
DEV: Add core feature spec

### DIFF
--- a/spec/system/core_feature_spec.rb
+++ b/spec/system/core_feature_spec.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+RSpec.describe "Core features", type: :system do
+  before { upload_theme }
+  it_behaves_like "having working core features", skip_examples: %i[topics search]
+end


### PR DESCRIPTION
This uses the core feature shared example to make sure
Horizon is not mistakenly breaking anything in core
