### PR TITLE
UX: fix group page container, round border

### DIFF
--- a/scss/main.scss
+++ b/scss/main.scss
@@ -72,16 +72,17 @@ body:not(.has-full-page-chat) {
       #topic-footer-buttons,
       .more-topics__container,
       .welcome-banner,
-      .container .user-main,
       .reviewable,
       .admin-content,
       .discourse-post-event-upcoming-events,
-      .container.groups-index,
       .body-page,
-      .container.badges,
       .topic-above-footer-buttons-outlet .presence-users,
       .global-notice,
-      .container.tags-index {
+      .container .user-main,
+      .container.groups-index,
+      .container.badges,
+      .container.tags-index,
+      .container.group {
         @include breakpoint(medium, $rule: min-width) {
           max-width: 1000px;
           margin-inline: auto;

--- a/scss/misc.scss
+++ b/scss/misc.scss
@@ -94,3 +94,7 @@ input[type="color"]:focus,
 .discourse-reactions-list .reactions {
   gap: 0.15em;
 }
+
+.group-details-container {
+  border-radius: var(--d-border-radius);
+}


### PR DESCRIPTION
Fixes the spacing on the group container and rounds the header 

Before:

![image](https://github.com/user-attachments/assets/3384841a-82b0-4f17-a0be-a32bd405bd29)


After:

![image](https://github.com/user-attachments/assets/1450cb2d-bd7a-4fb4-b7a8-b800b8b40d0d)
